### PR TITLE
Fix readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Reserved keys that are set automatically by the Hoodie store are:
 ```
 ## Source
 
-The source code is available o Github:
+The source code is available on Github:
 https://github.com/kaalita/Hoodie-iOS
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To get started with Hoodie-iOS, first install the Hoodie Server and create and s
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // This is the URL of the Hoodie API, after you started your Hoodie app
-    NSURL *baseURL = [[NSURL alloc] initWithString:@"http://localhost.:6001/_api"];
+    NSURL *baseURL = [NSURL URLWithString:@"http://localhost:6001/_api"];
     
     // Create new Hoodie instance with URL to your Hoodie API
     self.hoodie = [[HOOHoodie alloc] initWithBaseURL:baseURL];


### PR DESCRIPTION
Just some quick fixes. URL had a superfluous dot and I replaced `o` with `on`.

Thanks :dancers: 
